### PR TITLE
Hyperlinks to contributors websites / Fix URI replacement bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ brew install gnu-sed --with-default-names
 ```
 
 ## Contributors
-* Mark Howells-Mead | markweb.ch
-* Mauro Bringolf | maurobringolf.ch
-* Simon Bärlocher | sbaerlocher.ch
+* Mark Howells-Mead | [markweb.ch](https://markweb.ch)
+* Mauro Bringolf | [maurobringolf.ch](https://maurobringolf.ch)
+* Simon Bärlocher | [sbaerlocher.ch](https://sbaerlocher.ch)
 
 ## License
 Use this code freely, widely and for free. Provision of this code provides and implies no guarantee.

--- a/build-wordpress-plugin.sh
+++ b/build-wordpress-plugin.sh
@@ -22,6 +22,9 @@ function runPluginBuilder()
     echo "Author URI (website address)"
     read AUTHOR_URI
 
+    # Escape URI for regexp use within sed
+    AUTHOR_URI=$(echo $AUTHOR_URI | sed -e 's/\//\\\//g')
+
     echo "Author's vendor name (e.g. 'CompanyName')"
     read AUTHOR_NAMESPACE
 
@@ -33,6 +36,9 @@ function runPluginBuilder()
 
     echo "Plugin URI (e.g. GitHub URL)"
     read PLUGIN_URI
+
+    # Escape URI for regexp use within sed
+    PLUGIN_URI=$(echo $PLUGIN_URI | sed -e 's/\//\\\//g')
 
 	# Fetch the current base code from GitHub
     git clone https://github.com/WPSwitzerland/wp-plugin-default $PLUGIN_KEY
@@ -107,4 +113,3 @@ function runPluginBuilder()
 runPluginBuilder
 
 echo "You are good to go!"
-


### PR DESCRIPTION
I piped both URI inputs through sed, replacing all forward slashes with escaped forward slashes ```\/```. This fixes #2. Plus I hyperlinked Contributors websites in the ```README.md```.